### PR TITLE
Changes in QtXlsxWriter to work with qmake 3.0 and QT 5.0.2

### DIFF
--- a/src/xlsx/xlsxsharedstrings.cpp
+++ b/src/xlsx/xlsxsharedstrings.cpp
@@ -157,7 +157,7 @@ QSharedPointer<SharedStrings> SharedStrings::loadFromXmlFile(QIODevice *device)
          if (token == QXmlStreamReader::StartElement) {
              if (reader.name() == QLatin1String("sst")) {
                  QXmlStreamAttributes attributes = reader.attributes();
-                 count = attributes.value(QLatin1String("uniqueCount")).toInt();
+                 count = attributes.value(QLatin1String("uniqueCount")).toString().toInt();
              } else if (reader.name() == QLatin1String("si")) {
                  if (reader.readNextStartElement()) {
                      if (reader.name() == QLatin1String("t")) {

--- a/src/xlsx/xlsxstyles.cpp
+++ b/src/xlsx/xlsxstyles.cpp
@@ -577,14 +577,14 @@ bool Styles::readNumFmts(XmlStreamReader &reader)
 {
     Q_ASSERT(reader.name() == QLatin1String("numFmts"));
     QXmlStreamAttributes attributes = reader.attributes();
-    int count = attributes.value(QLatin1String("count")).toInt();
+    int count = attributes.value(QLatin1String("count")).toString().toInt();
     for (int i=0; i<count; ++i) {
         reader.readNextStartElement();
         if (reader.name() != QLatin1String("numFmt"))
             return false;
         QXmlStreamAttributes attributes = reader.attributes();
         QSharedPointer<NumberData> fmt (new NumberData);
-        fmt->formatIndex = attributes.value(QLatin1String("numFmtId")).toInt();
+        fmt->formatIndex = attributes.value(QLatin1String("numFmtId")).toString().toInt();
         fmt->formatString = attributes.value(QLatin1String("formatCode")).toString();
         if (fmt->formatIndex >= m_nextCustomNumFmtId)
             m_nextCustomNumFmtId = fmt->formatIndex + 1;
@@ -601,7 +601,7 @@ bool Styles::readFonts(XmlStreamReader &reader)
 {
     Q_ASSERT(reader.name() == QLatin1String("fonts"));
     QXmlStreamAttributes attributes = reader.attributes();
-    int count = attributes.value(QLatin1String("count")).toInt();
+    int count = attributes.value(QLatin1String("count")).toString().toInt();
     for (int i=0; i<count; ++i) {
         reader.readNextStartElement();
         if (reader.name() != QLatin1String("font"))
@@ -638,14 +638,14 @@ bool Styles::readFonts(XmlStreamReader &reader)
                     else
                         font->scirpt = Format::FontScriptSub;
                 } else if (reader.name() == QLatin1String("sz")) {
-                    font->size = reader.attributes().value(QLatin1String("val")).toInt();
+                    font->size = reader.attributes().value(QLatin1String("val")).toString().toInt();
                 } else if (reader.name() == QLatin1String("color")) {
                     QXmlStreamAttributes attributes = reader.attributes();
                     if (attributes.hasAttribute(QLatin1String("rgb"))) {
                         QString colorString = attributes.value(QLatin1String("rgb")).toString();
                         font->color = fromARGBString(colorString);
                     } else if (attributes.hasAttribute(QLatin1String("indexed"))) {
-                        font->color = getColorByIndex(attributes.value(QLatin1String("indexed")).toInt());
+                        font->color = getColorByIndex(attributes.value(QLatin1String("indexed")).toString().toInt());
                     } else if (attributes.hasAttribute(QLatin1String("theme"))) {
                         QString theme = attributes.value(QLatin1String("theme")).toString();
                         QString tint = attributes.value(QLatin1String("tint")).toString();
@@ -654,7 +654,7 @@ bool Styles::readFonts(XmlStreamReader &reader)
                 } else if (reader.name() == QLatin1String("name")) {
                     font->name = reader.attributes().value(QLatin1String("val")).toString();
                 } else if (reader.name() == QLatin1String("family")) {
-                    font->family = reader.attributes().value(QLatin1String("val")).toInt();
+                    font->family = reader.attributes().value(QLatin1String("val")).toString().toInt();
                 } else if (reader.name() == QLatin1String("scheme")) {
                     font->scheme = reader.attributes().value(QLatin1String("val")).toString();
                 }
@@ -675,7 +675,7 @@ bool Styles::readFills(XmlStreamReader &reader)
     Q_ASSERT(reader.name() == QLatin1String("fills"));
 
     QXmlStreamAttributes attributes = reader.attributes();
-    int count = attributes.value(QLatin1String("count")).toInt();
+    int count = attributes.value(QLatin1String("count")).toString().toInt();
     for (int i=0; i<count; ++i) {
         reader.readNextStartElement();
         if (reader.name() != QLatin1String("fill") || reader.tokenType() != QXmlStreamReader::StartElement)
@@ -725,7 +725,7 @@ bool Styles::readFill(XmlStreamReader &reader)
                 if (attributes.hasAttribute(QLatin1String("rgb"))) {
                     c = fromARGBString(attributes.value(QLatin1String("rgb")).toString());
                 } else if (attributes.hasAttribute(QLatin1String("indexed"))) {
-                    c = getColorByIndex(attributes.value(QLatin1String("indexed")).toInt());
+                    c = getColorByIndex(attributes.value(QLatin1String("indexed")).toString().toInt());
                 } else if (attributes.hasAttribute(QLatin1String("theme"))) {
                     QString theme = attributes.value(QLatin1String("theme")).toString();
                     QString tint = attributes.value(QLatin1String("tint")).toString();
@@ -741,7 +741,7 @@ bool Styles::readFill(XmlStreamReader &reader)
                 if (attributes.hasAttribute(QLatin1String("rgb"))) {
                     c = fromARGBString(attributes.value(QLatin1String("rgb")).toString());
                 } else if (attributes.hasAttribute(QLatin1String("indexed"))) {
-                    c = getColorByIndex(attributes.value(QLatin1String("indexed")).toInt());
+                    c = getColorByIndex(attributes.value(QLatin1String("indexed")).toString().toInt());
                 } else if (attributes.hasAttribute(QLatin1String("theme"))) {
                     QString theme = attributes.value(QLatin1String("theme")).toString();
                     QString tint = attributes.value(QLatin1String("tint")).toString();
@@ -770,7 +770,7 @@ bool Styles::readBorders(XmlStreamReader &reader)
     Q_ASSERT(reader.name() == QLatin1String("borders"));
 
     QXmlStreamAttributes attributes = reader.attributes();
-    int count = attributes.value(QLatin1String("count")).toInt();
+    int count = attributes.value(QLatin1String("count")).toString().toInt();
     for (int i=0; i<count; ++i) {
         reader.readNextStartElement();
         if (reader.name() != QLatin1String("border") || reader.tokenType() != QXmlStreamReader::StartElement)
@@ -857,7 +857,7 @@ bool Styles::readSubBorder(XmlStreamReader &reader, const QString &name, Format:
                             //get color
                             color = fromARGBString(colorString);
                         } else if (colorAttrs.hasAttribute(QLatin1String("indexed"))) {
-                            color = getColorByIndex(colorAttrs.value(QLatin1String("indexed")).toInt());
+                            color = getColorByIndex(colorAttrs.value(QLatin1String("indexed")).toString().toInt());
                         } else if (colorAttrs.hasAttribute(QLatin1String("theme"))) {
                             QString theme = attributes.value(QLatin1String("theme")).toString();
                             QString tint = attributes.value(QLatin1String("tint")).toString();
@@ -880,7 +880,7 @@ bool Styles::readCellXfs(XmlStreamReader &reader)
 {
     Q_ASSERT(reader.name() == QLatin1String("cellXfs"));
     QXmlStreamAttributes attributes = reader.attributes();
-    int count = attributes.value(QLatin1String("count")).toInt();
+    int count = attributes.value(QLatin1String("count")).toString().toInt();
     for (int i=0; i<count; ++i) {
         reader.readNextStartElement();
         if (reader.name() != QLatin1String("xf"))
@@ -893,7 +893,7 @@ bool Styles::readCellXfs(XmlStreamReader &reader)
 //            qDebug()<<"... "<<i<<" "<<xfAttrs[i].name()<<xfAttrs[i].value();
 
         if (xfAttrs.hasAttribute(QLatin1String("applyNumberFormat"))) {
-            int numFmtIndex = xfAttrs.value(QLatin1String("numFmtId")).toInt();
+            int numFmtIndex = xfAttrs.value(QLatin1String("numFmtId")).toString().toInt();
             if (!m_customNumFmtIdMap.contains(numFmtIndex))
                 format->setNumberFormatIndex(numFmtIndex);
             else
@@ -901,7 +901,7 @@ bool Styles::readCellXfs(XmlStreamReader &reader)
         }
 
         if (xfAttrs.hasAttribute(QLatin1String("applyFont"))) {
-            int fontIndex = xfAttrs.value(QLatin1String("fontId")).toInt();
+            int fontIndex = xfAttrs.value(QLatin1String("fontId")).toString().toInt();
             if (fontIndex >= m_fontsList.size()) {
                 qDebug("Error read styles.xml, cellXfs fontId");
             } else {
@@ -910,7 +910,7 @@ bool Styles::readCellXfs(XmlStreamReader &reader)
         }
 
         if (xfAttrs.hasAttribute(QLatin1String("applyFill"))) {
-            int id = xfAttrs.value(QLatin1String("fillId")).toInt();
+            int id = xfAttrs.value(QLatin1String("fillId")).toString().toInt();
             if (id >= m_fillsList.size()) {
                 qDebug("Error read styles.xml, cellXfs fillId");
             } else {
@@ -919,7 +919,7 @@ bool Styles::readCellXfs(XmlStreamReader &reader)
         }
 
         if (xfAttrs.hasAttribute(QLatin1String("applyBorder"))) {
-            int id = xfAttrs.value(QLatin1String("borderId")).toInt();
+            int id = xfAttrs.value(QLatin1String("borderId")).toString().toInt();
             if (id >= m_bordersList.size()) {
                 qDebug("Error read styles.xml, cellXfs borderId");
             } else {
@@ -961,12 +961,12 @@ bool Styles::readCellXfs(XmlStreamReader &reader)
                 }
 
                 if (alignAttrs.hasAttribute(QLatin1String("indent"))) {
-                    int indent = alignAttrs.value(QLatin1String("indent")).toInt();
+                    int indent = alignAttrs.value(QLatin1String("indent")).toString().toInt();
                     format->setIndent(indent);
                 }
 
                 if (alignAttrs.hasAttribute(QLatin1String("textRotation"))) {
-                    int rotation = alignAttrs.value(QLatin1String("textRotation")).toInt();
+                    int rotation = alignAttrs.value(QLatin1String("textRotation")).toString().toInt();
                     format->setRotation(rotation);
                 }
 

--- a/src/xlsx/xlsxworkbook.cpp
+++ b/src/xlsx/xlsxworkbook.cpp
@@ -394,7 +394,7 @@ bool Workbook::loadFromXmlFile(QIODevice *device)
                  XlsxSheetItemInfo info;
                  QXmlStreamAttributes attributes = reader.attributes();
                  info.name = attributes.value(QLatin1String("name")).toString();
-                 info.sheetId = attributes.value(QLatin1String("sheetId")).toInt();
+                 info.sheetId = attributes.value(QLatin1String("sheetId")).toString().toInt();
                  info.rId = attributes.value(QLatin1String("r:id")).toString();
                  if (attributes.hasAttribute(QLatin1String("state")))
                      info.state = attributes.value(QLatin1String("state")).toString();
@@ -410,17 +410,17 @@ bool Workbook::loadFromXmlFile(QIODevice *device)
                         if (reader.name() == QLatin1String("workbookView")) {
                             QXmlStreamAttributes attrs = reader.attributes();
                             if (attrs.hasAttribute(QLatin1String("xWindow")))
-                                d->x_window = attrs.value(QLatin1String("xWindow")).toInt();
+                                d->x_window = attrs.value(QLatin1String("xWindow")).toString().toInt();
                             if (attrs.hasAttribute(QLatin1String("yWindow")))
-                                d->y_window = attrs.value(QLatin1String("yWindow")).toInt();
+                                d->y_window = attrs.value(QLatin1String("yWindow")).toString().toInt();
                             if (attrs.hasAttribute(QLatin1String("windowWidth")))
-                                d->window_width = attrs.value(QLatin1String("windowWidth")).toInt();
+                                d->window_width = attrs.value(QLatin1String("windowWidth")).toString().toInt();
                             if (attrs.hasAttribute(QLatin1String("windowHeight")))
-                                d->window_height = attrs.value(QLatin1String("windowHeight")).toInt();
+                                d->window_height = attrs.value(QLatin1String("windowHeight")).toString().toInt();
                             if (attrs.hasAttribute(QLatin1String("firstSheet")))
-                                d->firstsheet = attrs.value(QLatin1String("firstSheet")).toInt();
+                                d->firstsheet = attrs.value(QLatin1String("firstSheet")).toString().toInt();
                             if (attrs.hasAttribute(QLatin1String("activeTab")))
-                                d->activesheet = attrs.value(QLatin1String("activeTab")).toInt();
+                                d->activesheet = attrs.value(QLatin1String("activeTab")).toString().toInt();
                         }
                     }
                 }
@@ -432,7 +432,7 @@ bool Workbook::loadFromXmlFile(QIODevice *device)
                  if (attrs.hasAttribute(QLatin1String("comment")))
                      data.comment = attrs.value(QLatin1String("comment")).toString();
                  if (attrs.hasAttribute(QLatin1String("localSheetId"))) {
-                     int localId = attrs.value(QLatin1String("localSheetId")).toInt();
+                     int localId = attrs.value(QLatin1String("localSheetId")).toString().toInt();
                      int sheetId = d->sheetItemInfoList[localId].sheetId;
                      data.sheetId = sheetId;
                  }

--- a/src/xlsx/xlsxworksheet.cpp
+++ b/src/xlsx/xlsxworksheet.cpp
@@ -1831,22 +1831,22 @@ void WorksheetPrivate::readSheetData(XmlStreamReader &reader)
 
                     QSharedPointer<XlsxRowInfo> info(new XlsxRowInfo);
                     if (attributes.hasAttribute(QLatin1String("customFormat")) && attributes.hasAttribute(QLatin1String("s"))) {
-                        int idx = attributes.value(QLatin1String("s")).toInt();
+                        int idx = attributes.value(QLatin1String("s")).toString().toInt();
                         info->format = workbook->styles()->xfFormat(idx);
                     }
                     if (attributes.hasAttribute(QLatin1String("customHeight")) && attributes.hasAttribute(QLatin1String("ht"))) {
-                        info->height = attributes.value(QLatin1String("ht")).toDouble();
+                        info->height = attributes.value(QLatin1String("ht")).toString().toDouble();
                     }
                     //both "hidden" and "collapsed" default are false
                     info->hidden = attributes.value(QLatin1String("hidden")) == QLatin1String("1");
                     info->collapsed = attributes.value(QLatin1String("collapsed")) == QLatin1String("1");
 
                     if (attributes.hasAttribute(QLatin1String("outlineLevel")))
-                        info->outlineLevel = attributes.value(QLatin1String("outlineLevel")).toInt();
+                        info->outlineLevel = attributes.value(QLatin1String("outlineLevel")).toString().toInt();
 
                     //"r" is optional too.
                     if (attributes.hasAttribute(QLatin1String("r"))) {
-                        int row = attributes.value(QLatin1String("r")).toInt();
+                        int row = attributes.value(QLatin1String("r")).toString().toInt();
                         rowsInfo[row] = info;
                     }
                 }
@@ -1859,7 +1859,7 @@ void WorksheetPrivate::readSheetData(XmlStreamReader &reader)
                 //get format
                 Format *format = 0;
                 if (attributes.hasAttribute(QLatin1String("s"))) {
-                    int idx = attributes.value(QLatin1String("s")).toInt();
+                    int idx = attributes.value(QLatin1String("s")).toString().toInt();
                     format = workbook->styles()->xfFormat(idx);
                     if (!format)
                         qDebug()<<QStringLiteral("<c s=\"%1\">Invalid style index: ").arg(idx)<<idx;
@@ -1950,15 +1950,15 @@ void WorksheetPrivate::readColumnsInfo(XmlStreamReader &reader)
                 QSharedPointer<XlsxColumnInfo> info(new XlsxColumnInfo);
 
                 QXmlStreamAttributes colAttrs = reader.attributes();
-                int min = colAttrs.value(QLatin1String("min")).toInt();
-                int max = colAttrs.value(QLatin1String("max")).toInt();
+                int min = colAttrs.value(QLatin1String("min")).toString().toInt();
+                int max = colAttrs.value(QLatin1String("max")).toString().toInt();
                 info->firstColumn = min;
                 info->lastColumn = max;
 
                 //!Todo, customWidth support.
                 //Note, node may have "width" without "customWidth"
                 if (colAttrs.hasAttribute(QLatin1String("width"))) {
-                    double width = colAttrs.value(QLatin1String("width")).toDouble();
+                    double width = colAttrs.value(QLatin1String("width")).toString().toDouble();
                     info->width = width;
                 }
 
@@ -1966,11 +1966,11 @@ void WorksheetPrivate::readColumnsInfo(XmlStreamReader &reader)
                 info->collapsed = colAttrs.value(QLatin1String("collapsed")) == QLatin1String("1");
 
                 if (colAttrs.hasAttribute(QLatin1String("style"))) {
-                    int idx = colAttrs.value(QLatin1String("style")).toInt();
+                    int idx = colAttrs.value(QLatin1String("style")).toString().toInt();
                     info->format = workbook->styles()->xfFormat(idx);
                 }
                 if (colAttrs.hasAttribute(QLatin1String("outlineLevel")))
-                    info->outlineLevel = colAttrs.value(QLatin1String("outlineLevel")).toInt();
+                    info->outlineLevel = colAttrs.value(QLatin1String("outlineLevel")).toString().toInt();
 
                 colsInfo.insert(min, info);
                 for (int col=min; col<=max; ++col)
@@ -1985,7 +1985,7 @@ void WorksheetPrivate::readMergeCells(XmlStreamReader &reader)
     Q_ASSERT(reader.name() == QLatin1String("mergeCells"));
 
     QXmlStreamAttributes attributes = reader.attributes();
-    int count = attributes.value(QLatin1String("count")).toInt();
+    int count = attributes.value(QLatin1String("count")).toString().toInt();
 
     while(!(reader.name() == QLatin1String("mergeCells") && reader.tokenType() == QXmlStreamReader::EndElement)) {
         reader.readNextStartElement();
@@ -2014,7 +2014,7 @@ void WorksheetPrivate::readDataValidations(XmlStreamReader &reader)
 {
     Q_ASSERT(reader.name() == QLatin1String("dataValidations"));
     QXmlStreamAttributes attributes = reader.attributes();
-    int count = attributes.value(QLatin1String("count")).toInt();
+    int count = attributes.value(QLatin1String("count")).toString().toInt();
 
     while(!(reader.name() == QLatin1String("dataValidations")
             && reader.tokenType() == QXmlStreamReader::EndElement)) {


### PR DESCRIPTION
In QT prior to 5.1.x there is no function toInt() or toDouble() in class QStringRef
It can be fixed by converting QStringRef to a string with function toString() and convert this string to double or int.
