### PR TITLE
avoid shadowing member

### DIFF
--- a/src/xlsx/xlsxcellreference.h
+++ b/src/xlsx/xlsxcellreference.h
@@ -41,7 +41,7 @@ public:
     QString toString(bool row_abs=false, bool col_abs=false) const;
     static CellReference fromString(const QString &cell);
     bool isValid() const;
-    inline void setRow(int row) { _row = row; }
+    inline void setRow(int arow) { _row = arow; }
     inline void setColumn(int col) { _column = col; }
     inline int row() const { return _row; }
     inline int column() const { return _column; }


### PR DESCRIPTION
The parameter row shadows the member method row(), which generates
warning or error.