### PR TITLE
fix build on Qt 5.6

### DIFF
--- a/src/xlsx/xlsxzipreader.cpp
+++ b/src/xlsx/xlsxzipreader.cpp
@@ -48,7 +48,7 @@ ZipReader::~ZipReader()
 
 void ZipReader::init()
 {
-    QList<QZipReader::FileInfo> allFiles = m_reader->fileInfoList();
+    const QVector<QZipReader::FileInfo> allFiles = m_reader->fileInfoList();
     foreach (const QZipReader::FileInfo &fi, allFiles) {
         if (fi.isFile)
             m_filePaths.append(fi.filePath);


### PR DESCRIPTION
Converting QVector to QList doesn't work here, but it should
be fine to just keep it as QVector.