### PR TITLE
Allow CMake tool usage for library and test compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,14 @@ cmake_minimum_required(VERSION 3.2)
 
 project(QtXlsxWriter)
 add_definitions(-DQT_BUILD_XLSX_LIB)
-SET (BUILD_SHARED_LIBS TRUE)
-
+set(BUILD_SHARED_LIBS TRUE)
 set(CMAKE_AUTOMOC ON)
 
 file(
 	GLOB
 	QtXlsxWriter_SOURCE_FILES 
 	${CMAKE_CURRENT_SOURCE_DIR}/src/xlsx/*.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/QtXlsxWriterTest_automoc.cpp
 )
 
 find_package(Qt5 5.5 REQUIRED Core Gui Test)
@@ -26,11 +26,7 @@ target_link_libraries(QtXlsxWriter ${Qt5Core_LIBRARIES})
 target_link_libraries(QtXlsxWriter ${Qt5Gui_LIBRARIES})
 
 if(BUILD_TESTS)
-
-add_custom_command(TARGET QtXlsxWriter POST_BUILD
-  COMMAND ${CMAKE_COMMAND} 
-  -E copy_directory $<CONFIGURATION>/ ${CMAKE_CURRENT_BINARY_DIR}/tests/auto/$<CONFIGURATION>/)
-	add_subdirectory(tests)
+  add_subdirectory(tests)
 endif()
 
 if(BUILD_EXAMPLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 3.2)
 
 project(QtXlsxWriter)
-add_definitions(-DXLSX_NO_LIB)
-SET (BUILD_SHARED_LIBS  TRUE) 
+add_definitions(-DQT_BUILD_XLSX_LIB)
+SET (BUILD_SHARED_LIBS TRUE)
 
 set(CMAKE_AUTOMOC ON)
+
 file(
 	GLOB
 	QtXlsxWriter_SOURCE_FILES 
@@ -20,10 +21,15 @@ include_directories(
 
 add_library(QtXlsxWriter SHARED "${QtXlsxWriter_SOURCE_FILES}")
 
+set_target_properties(QtXlsxWriter PROPERTIES DEBUG_POSTFIX "d")
 target_link_libraries(QtXlsxWriter ${Qt5Core_LIBRARIES})
 target_link_libraries(QtXlsxWriter ${Qt5Gui_LIBRARIES})
 
 if(BUILD_TESTS)
+
+add_custom_command(TARGET QtXlsxWriter POST_BUILD
+  COMMAND ${CMAKE_COMMAND} 
+  -E copy_directory $<CONFIGURATION>/ ${CMAKE_CURRENT_BINARY_DIR}/tests/auto/$<CONFIGURATION>/)
 	add_subdirectory(tests)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.2)
+
+project(QtXlsxWriter)
+add_definitions(-DXLSX_NO_LIB)
+SET (BUILD_SHARED_LIBS  TRUE) 
+
+set(CMAKE_AUTOMOC ON)
+file(
+	GLOB
+	QtXlsxWriter_SOURCE_FILES 
+	${CMAKE_CURRENT_SOURCE_DIR}/src/xlsx/*.cpp
+)
+
+find_package(Qt5 5.5 REQUIRED Core Gui Test)
+include_directories(
+	${QtXlsxWriter_SOURCE_FILES} 
+	${Qt5Core_INCLUDE_DIRS} 
+	${Qt5Gui_INCLUDE_DIRS}
+	${Qt5Gui_PRIVATE_INCLUDE_DIRS} )
+
+add_library(QtXlsxWriter SHARED "${QtXlsxWriter_SOURCE_FILES}")
+
+target_link_libraries(QtXlsxWriter ${Qt5Core_LIBRARIES})
+target_link_libraries(QtXlsxWriter ${Qt5Gui_LIBRARIES})
+
+if(BUILD_TESTS)
+	add_subdirectory(tests)
+endif()
+
+if(BUILD_EXAMPLES)
+	add_subdirectory(examples)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(auto)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,54 @@
+# create a test-enabled library first (export more functions than regular DLL)
+
+# Create a fake private/ include folder 
+# in the compilation tree to allow the
+# #include "private/..." instruction to
+# work
+set( 
+	QtXlsxWriter_PRIVATE_SOURCE_FILES 
+    	${CMAKE_CURRENT_BINARY_DIR}/include)
+
+if(DEBUG)
+	message("Private include directory : ${QtXlsxWriter_PRIVATE_SOURCE_FILES}")
+endif()
+file(MAKE_DIRECTORY "${QtXlsxWriter_PRIVATE_SOURCE_FILES}/private")
+
+# Copy all private includes in the created folder
+file(GLOB private_includes ${CMAKE_CURRENT_SOURCE_DIR}/../src/xlsx/*_p.h)
+foreach(private_include ${private_includes})
+	if(DEBUG)
+		message("Copying private include : ${private_include}") 
+	endif()
+	file(COPY ${private_include} DESTINATION ${QtXlsxWriter_PRIVATE_SOURCE_FILES}/private)
+endforeach()
+
+set(CMAKE_AUTOMOC ON)
+
+file(
+  GLOB
+  QtXlsxWriterTest_SOURCE_FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/../src/xlsx/*.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/QtXlsxWriter_automoc.cpp
+)
+
+include_directories(
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ${Qt5Core_INCLUDE_DIRS} 
+  ${Qt5Gui_INCLUDE_DIRS}
+  ${Qt5Gui_PRIVATE_INCLUDE_DIRS}
+)
+  
+add_definitions(-DQT_BUILD_XLSX_LIB)
+add_definitions(-DXLSX_TEST)
+add_library(QtXlsxWriterTest SHARED "${QtXlsxWriterTest_SOURCE_FILES}")
+  
+set_target_properties(QtXlsxWriterTest PROPERTIES DEBUG_POSTFIX "d")
+  
+target_link_libraries(QtXlsxWriterTest ${Qt5Core_LIBRARIES})
+target_link_libraries(QtXlsxWriterTest ${Qt5Gui_LIBRARIES})
+
+add_custom_command(TARGET QtXlsxWriterTest POST_BUILD
+                     COMMAND ${CMAKE_COMMAND}
+                     -E copy_directory $<CONFIGURATION> auto/$<CONFIGURATION>)
+
 add_subdirectory(auto)

--- a/tests/auto/CMakeLists.txt
+++ b/tests/auto/CMakeLists.txt
@@ -12,35 +12,11 @@ set(TESTS
 	worksheet 
 	xlsxconditionalformatting 
 	zipreader)
-
-
+  
 enable_testing()
 
-# Create a fake private/ include folder in
-# the compilation tree
-set( 
-	QtXlsxWriter_PRIVATE_SOURCE_FILES 
-    	${CMAKE_CURRENT_BINARY_DIR}/include)
-
-if(DEBUG)
-	message("Private include directory : ${QtXlsxWriter_PRIVATE_SOURCE_FILES}")
-endif()
-
-file(MAKE_DIRECTORY "${QtXlsxWriter_PRIVATE_SOURCE_FILES}/private")
-
-
-# and copy all private includes in it
-file(GLOB private_includes ${CMAKE_CURRENT_SOURCE_DIR}/../../src/xlsx/*_p.h)
-foreach(private_include ${private_includes})
-	if(DEBUG)
-		message("Copying private include : ${private_include}") 
-	endif()
-	file(COPY ${private_include} DESTINATION ${QtXlsxWriter_PRIVATE_SOURCE_FILES}/private)
-endforeach()
-
-add_definitions(-DXLSX_TESTS)
-add_definitions(-DXLSX_NO_LIB)
-
+# Compile each defined test and
+# declare it for ctest tool
 foreach(test IN ITEMS ${TESTS})
 	if(DEBUG)
 		message("configure test '${test}'")
@@ -50,13 +26,20 @@ foreach(test IN ITEMS ${TESTS})
 		${CMAKE_CURRENT_SOURCE_DIR}/../../src/xlsx/
 		${Qt5Core_INCLUDE_DIRS} 
 		${Qt5Gui_INCLUDE_DIRS}
-		${QtXlsxWriter_PRIVATE_SOURCE_FILES}
+    ${QtXlsxWriter_PRIVATE_SOURCE_FILES}
 		${CMAKE_CURRENT_BINARY_DIR} # .moc files
 	)
-	add_executable(${test}_testDriver ${TEST_SRC})
-  	target_link_libraries(${test}_testDriver QtXlsxWriter)
-	target_link_libraries(${test}_testDriver ${Qt5Core_LIBRARIES})
+  
+  add_definitions(-DXLSX_TEST)
+  remove_definitions(-DQT_BUILD_XLSX_LIB)
+
+	add_executable(${test}_testDriver ${TEST_SRC} )
+
+  target_link_libraries(${test}_testDriver ${Qt5Core_LIBRARIES})
 	target_link_libraries(${test}_testDriver ${Qt5Gui_LIBRARIES})
 	target_link_libraries(${test}_testDriver ${Qt5Test_LIBRARIES})
-	add_test(NAME ${test} COMMAND ${test}_testDriver)
+  target_link_libraries(${test}_testDriver QtXlsxWriterTest)
+
+  add_test(NAME ${test} COMMAND ${test}_testDriver)
+
 endforeach(test)

--- a/tests/auto/CMakeLists.txt
+++ b/tests/auto/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 
 file(MAKE_DIRECTORY "${QtXlsxWriter_PRIVATE_SOURCE_FILES}/private")
 
+
 # and copy all private includes in it
 file(GLOB private_includes ${CMAKE_CURRENT_SOURCE_DIR}/../../src/xlsx/*_p.h)
 foreach(private_include ${private_includes})
@@ -37,8 +38,9 @@ foreach(private_include ${private_includes})
 	file(COPY ${private_include} DESTINATION ${QtXlsxWriter_PRIVATE_SOURCE_FILES}/private)
 endforeach()
 
-
 add_definitions(-DXLSX_TESTS)
+add_definitions(-DXLSX_NO_LIB)
+
 foreach(test IN ITEMS ${TESTS})
 	if(DEBUG)
 		message("configure test '${test}'")
@@ -56,5 +58,5 @@ foreach(test IN ITEMS ${TESTS})
 	target_link_libraries(${test}_testDriver ${Qt5Core_LIBRARIES})
 	target_link_libraries(${test}_testDriver ${Qt5Gui_LIBRARIES})
 	target_link_libraries(${test}_testDriver ${Qt5Test_LIBRARIES})
-	add_test(NAME ${test} COMMAND ${test}_testDriver -C $<CONFIGURATION>)
+	add_test(NAME ${test} COMMAND ${test}_testDriver)
 endforeach(test)

--- a/tests/auto/CMakeLists.txt
+++ b/tests/auto/CMakeLists.txt
@@ -1,0 +1,60 @@
+set(TESTS 
+	cellreference  
+	document 
+	format 
+	propsapp 
+	propscore 
+	relationships 
+	richstring 
+	sharedstrings 
+	styles 
+	utility 
+	worksheet 
+	xlsxconditionalformatting 
+	zipreader)
+
+
+enable_testing()
+
+# Create a fake private/ include folder in
+# the compilation tree
+set( 
+	QtXlsxWriter_PRIVATE_SOURCE_FILES 
+    	${CMAKE_CURRENT_BINARY_DIR}/include)
+
+if(DEBUG)
+	message("Private include directory : ${QtXlsxWriter_PRIVATE_SOURCE_FILES}")
+endif()
+
+file(MAKE_DIRECTORY "${QtXlsxWriter_PRIVATE_SOURCE_FILES}/private")
+
+# and copy all private includes in it
+file(GLOB private_includes ${CMAKE_CURRENT_SOURCE_DIR}/../../src/xlsx/*_p.h)
+foreach(private_include ${private_includes})
+	if(DEBUG)
+		message("Copying private include : ${private_include}") 
+	endif()
+	file(COPY ${private_include} DESTINATION ${QtXlsxWriter_PRIVATE_SOURCE_FILES}/private)
+endforeach()
+
+
+add_definitions(-DXLSX_TESTS)
+foreach(test IN ITEMS ${TESTS})
+	if(DEBUG)
+		message("configure test '${test}'")
+	endif()
+	file( GLOB TEST_SRC ${test}/*.cpp)
+	include_directories(
+		${CMAKE_CURRENT_SOURCE_DIR}/../../src/xlsx/
+		${Qt5Core_INCLUDE_DIRS} 
+		${Qt5Gui_INCLUDE_DIRS}
+		${QtXlsxWriter_PRIVATE_SOURCE_FILES}
+		${CMAKE_CURRENT_BINARY_DIR} # .moc files
+	)
+	add_executable(${test}_testDriver ${TEST_SRC})
+  	target_link_libraries(${test}_testDriver QtXlsxWriter)
+	target_link_libraries(${test}_testDriver ${Qt5Core_LIBRARIES})
+	target_link_libraries(${test}_testDriver ${Qt5Gui_LIBRARIES})
+	target_link_libraries(${test}_testDriver ${Qt5Test_LIBRARIES})
+	add_test(NAME ${test} COMMAND ${test}_testDriver -C $<CONFIGURATION>)
+endforeach(test)


### PR DESCRIPTION
Allow to use CMake rather than QMake as build system.
Use : 
cmake -DBUILD_TEST=ON -DQt5_DIR=[QT ROOT]/lib/cmake/qt5