### PR TITLE
Resolve compile error with qt 5.6.0+

### DIFF
--- a/src/xlsx/xlsxzipreader.cpp
+++ b/src/xlsx/xlsxzipreader.cpp
@@ -48,7 +48,7 @@ ZipReader::~ZipReader()
 
 void ZipReader::init()
 {
-    QList<QZipReader::FileInfo> allFiles = m_reader->fileInfoList();
+    QVector<QZipReader::FileInfo> allFiles = m_reader->fileInfoList();
     foreach (const QZipReader::FileInfo &fi, allFiles) {
         if (fi.isFile)
             m_filePaths.append(fi.filePath);

--- a/src/xlsx/xlsxzipwriter_p.h
+++ b/src/xlsx/xlsxzipwriter_p.h
@@ -37,6 +37,7 @@
 //
 
 #include <QString>
+#include <QVector>
 class QIODevice;
 class QZipWriter;
 


### PR DESCRIPTION
hi
because in qt 5.6.0 and above,  QZipReader::fileInfoList()  function returns QVector instead of QList, by edit this classes this code can compiled with the latest version of qt.
thanks you